### PR TITLE
feat: update cache coordinates

### DIFF
--- a/.graphclientrc.yml
+++ b/.graphclientrc.yml
@@ -7,6 +7,10 @@ sources:
 plugins:
   - responseCache:
       ttlPerCoordinate:
+        - coordinate: Query.pools
+          ttl: 30 # 30 seconds
+        - coordinate: Query.bins
+          ttl: 60 # 1 minute
         - coordinate: Query.*
           ttl: 300 # 5 minutes
 

--- a/.graphclientrc.yml
+++ b/.graphclientrc.yml
@@ -8,11 +8,11 @@ plugins:
   - responseCache:
       ttlPerCoordinate:
         - coordinate: Query.pools
-          ttl: 30 # 30 seconds
+          ttl: 30000 # 30 seconds
         - coordinate: Query.bins
-          ttl: 60 # 1 minute
+          ttl: 60000 # 1 minute
         - coordinate: Query.*
-          ttl: 300 # 5 minutes
+          ttl: 300000 # 5 minutes
 
 cache:
   cfwKv:


### PR DESCRIPTION
This config makes `pools` query TTL 30 sec, `bins` query `1 min` and everything else be `5 min`

